### PR TITLE
Added or clause to check for valid timer

### DIFF
--- a/Pitch Perfect/PlayViewController.swift
+++ b/Pitch Perfect/PlayViewController.swift
@@ -196,7 +196,7 @@ extension PlayViewController: UICollectionViewDelegate, UICollectionViewDataSour
         let modulator = modulators[indexPath.item]
 
         // Only play the sound if there isnt a sound playing right now.
-        if stopTimer == nil {
+        if stopTimer == nil  || !stopTimer.valid{
             playSound(modulator)
         }
     }


### PR DESCRIPTION
## **What is this?**

After playing a sound on the Play screen, I was unable to play another the same sound again
## **What did I do?**

The if-statement that was checking to see if playSound(modulator) should be called was only checking for the stopTimer to be nil. This is wrong, because after the first time that a sound is played, stopTimer doesnt turn nil; it just gets invalidated. I added an or-clause that checks for an invalid timer, signifying that playSound is okay to run
