### PR TITLE
Added section inset to add a space between navbar and the modulators

### DIFF
--- a/Pitch Perfect/Base.lproj/Main.storyboard
+++ b/Pitch Perfect/Base.lproj/Main.storyboard
@@ -89,11 +89,11 @@
                                     <size key="itemSize" width="100" height="100"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="20" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="modulatorCell" id="ri0-0q-hXs" customClass="ModulatorCollectionViewCell" customModule="Pitch_Perfect" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                                        <rect key="frame" x="0.0" y="20" width="100" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                             <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
@@ -125,7 +125,7 @@
                                         </connections>
                                     </collectionViewCell>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="addModulatorCell" id="LNt-Fp-Anb">
-                                        <rect key="frame" x="190" y="0.0" width="100" height="100"/>
+                                        <rect key="frame" x="190" y="20" width="100" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                             <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>


### PR DESCRIPTION
# What is this?

There was no space between the navbar and the modulators. This looked really ugly.
# What did I do?

I added a section inset to add space between the navbar and the modulators. This is hardcoded to 20 right now. The section inset is better because you can scroll upwards and the buttons will hide behind the nav bar

![image](https://cloud.githubusercontent.com/assets/5385681/17458588/c72b5612-5be3-11e6-8595-29cbf77ce1d6.png)
